### PR TITLE
fix: get data row collection

### DIFF
--- a/src/mappers/ColumnMapper.php
+++ b/src/mappers/ColumnMapper.php
@@ -56,8 +56,7 @@ class ColumnMapper
                     : isset($model[$column->attribute]) ? $model[$column->attribute]: null;
 
                 $value = $this->getColumnValue($column, $model, $key, $index);
-                $header = $this->columnHeader ? $this->getColumnHeader($column): $column->attribute;
-                $row[$header] = $value;
+                $row[] = $value;
             }
         }
 


### PR DESCRIPTION
When exporting a table with the same column names, the next ones override the previous ones.